### PR TITLE
Revert "Update Configs.py"

### DIFF
--- a/Config/Configs.py
+++ b/Config/Configs.py
@@ -65,7 +65,7 @@ class VConfigs(Singleton):
             Or use this direct URL: {}""")
 
             self.MY_ERROR_BAD_COMMAND = os.getenv('MY_ERROR_BAD_COMMAND', 'This string serves to verify if some error was raised by myself on purpose')
-            self.INVITE_URL = os.getenv('INVITE_URL', 'https://discordapp.com/oauth2/authorize?client_id={}&permissions=8&scope=bot')
+            self.INVITE_URL = os.getenv('INVITE_URL', 'https://discordapp.com/oauth2/authorize?client_id={}&scope=bot')
 
     def getPlayersManager(self):
         return self.__manager


### PR DESCRIPTION
Reverts RafaelSolVargas/Vulkan#66

I don't believe this is beneficial. Especially if the bot is self hosted, with a lot of people ignoring critical security measures. Instead, needed permissions could be added, like talking in voice channels, sending messages with embeds, adding reactions to messages, etc... . I don't think that the Administrator shortcut is a good excuse because it allows anyone with the bot (or just its token, same thing) to do anything in the server, for the better and for the worse.